### PR TITLE
fix : install guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,17 +16,11 @@ Asset load helper for pixi.js
 
 ### Install
 
-pixijs-loader-util depend on [pixi.js](https://github.com/pixijs/pixi.js)
-
-```bash
-npm install pixi.js --save-dev
-```
-
-and
-
 ```bash
 npm install @masatomakino/pixijs-loader-util --save-dev
 ```
+
+pixijs-loader-util depend on [pixi.js](https://github.com/pixijs/pixi.js)
 
 ### Import
 


### PR DESCRIPTION
pixi.jsをpeerDependenciesに移動したため、個別のインストールが不要になった。